### PR TITLE
Add ruby lang version for each jruby download

### DIFF
--- a/files/downloads/index.html
+++ b/files/downloads/index.html
@@ -5,127 +5,501 @@ title: Files/downloads
 <h1>Files/downloads</h1>
 <p class="trackDownloads">
   <a href='/files/index.html'>..</a><br/>
-  <a href='/files/downloads/0.9.0/index.html'>0.9.0</a><br/>
-  <a href='/files/downloads/0.9.1/index.html'>0.9.1</a><br/>
-  <a href='/files/downloads/0.9.2/index.html'>0.9.2</a><br/>
-  <a href='/files/downloads/0.9.8/index.html'>0.9.8</a><br/>
-  <a href='/files/downloads/0.9.9/index.html'>0.9.9</a><br/>
-  <a href='/files/downloads/1.0.0RC1/index.html'>1.0.0RC1</a><br/>
-  <a href='/files/downloads/1.0.0RC2/index.html'>1.0.0RC2</a><br/>
-  <a href='/files/downloads/1.0.0RC3/index.html'>1.0.0RC3</a><br/>
-  <a href='/files/downloads/1.0.1/index.html'>1.0.1</a><br/>
-  <a href='/files/downloads/1.0.2/index.html'>1.0.2</a><br/>
-  <a href='/files/downloads/1.0.3/index.html'>1.0.3</a><br/>
-  <a href='/files/downloads/1.0/index.html'>1.0</a><br/>
-  <a href='/files/downloads/1.1.1/index.html'>1.1.1</a><br/>
-  <a href='/files/downloads/1.1.2/index.html'>1.1.2</a><br/>
-  <a href='/files/downloads/1.1.3/index.html'>1.1.3</a><br/>
-  <a href='/files/downloads/1.1.4/index.html'>1.1.4</a><br/>
-  <a href='/files/downloads/1.1.5/index.html'>1.1.5</a><br/>
-  <a href='/files/downloads/1.1.6/index.html'>1.1.6</a><br/>
-  <a href='/files/downloads/1.1.6RC1/index.html'>1.1.6RC1</a><br/>
-  <a href='/files/downloads/1.1/index.html'>1.1</a><br/>
-  <a href='/files/downloads/1.1RC1/index.html'>1.1RC1</a><br/>
-  <a href='/files/downloads/1.1RC2/index.html'>1.1RC2</a><br/>
-  <a href='/files/downloads/1.1RC3/index.html'>1.1RC3</a><br/>
-  <a href='/files/downloads/1.1b1/index.html'>1.1b1</a><br/>
-  <a href='/files/downloads/1.2.0/index.html'>1.2.0</a><br/>
-  <a href='/files/downloads/1.2.0RC1/index.html'>1.2.0RC1</a><br/>
-  <a href='/files/downloads/1.2.0RC2/index.html'>1.2.0RC2</a><br/>
-  <a href='/files/downloads/1.3.0/index.html'>1.3.0</a><br/>
-  <a href='/files/downloads/1.3.0RC1/index.html'>1.3.0RC1</a><br/>
-  <a href='/files/downloads/1.3.0RC2/index.html'>1.3.0RC2</a><br/>
-  <a href='/files/downloads/1.3.1/index.html'>1.3.1</a><br/>
-  <a href='/files/downloads/1.4.0/index.html'>1.4.0</a><br/>
-  <a href='/files/downloads/1.4.0RC1/index.html'>1.4.0RC1</a><br/>
-  <a href='/files/downloads/1.4.0RC2/index.html'>1.4.0RC2</a><br/>
-  <a href='/files/downloads/1.4.0RC3/index.html'>1.4.0RC3</a><br/>
-  <a href='/files/downloads/1.4.1/index.html'>1.4.1</a><br/>
-  <a href='/files/downloads/1.5.0.RC1/index.html'>1.5.0.RC1</a><br/>
-  <a href='/files/downloads/1.5.0.RC2/index.html'>1.5.0.RC2</a><br/>
-  <a href='/files/downloads/1.5.0.RC3/index.html'>1.5.0.RC3</a><br/>
-  <a href='/files/downloads/1.5.0/index.html'>1.5.0</a><br/>
-  <a href='/files/downloads/1.5.1/index.html'>1.5.1</a><br/>
-  <a href='/files/downloads/1.5.2/index.html'>1.5.2</a><br/>
-  <a href='/files/downloads/1.5.3/index.html'>1.5.3</a><br/>
-  <a href='/files/downloads/1.5.4/index.html'>1.5.4</a><br/>
-  <a href='/files/downloads/1.5.5/index.html'>1.5.5</a><br/>
-  <a href='/files/downloads/1.5.6/index.html'>1.5.6</a><br/>
-  <a href='/files/downloads/1.6.0.RC1/index.html'>1.6.0.RC1</a><br/>
-  <a href='/files/downloads/1.6.0.RC2/index.html'>1.6.0.RC2</a><br/>
-  <a href='/files/downloads/1.6.0.RC3/index.html'>1.6.0.RC3</a><br/>
-  <a href='/files/downloads/1.6.0/index.html'>1.6.0</a><br/>
-  <a href='/files/downloads/1.6.1/index.html'>1.6.1</a><br/>
-  <a href='/files/downloads/1.6.2/index.html'>1.6.2</a><br/>
-  <a href='/files/downloads/1.6.3/index.html'>1.6.3</a><br/>
-  <a href='/files/downloads/1.6.4/index.html'>1.6.4</a><br/>
-  <a href='/files/downloads/1.6.5.1/index.html'>1.6.5.1</a><br/>
-  <a href='/files/downloads/1.6.5/index.html'>1.6.5</a><br/>
-  <a href='/files/downloads/1.6.6/index.html'>1.6.6</a><br/>
-  <a href='/files/downloads/1.6.7.2/index.html'>1.6.7.2</a><br/>
-  <a href='/files/downloads/1.6.7/index.html'>1.6.7</a><br/>
-  <a href='/files/downloads/1.6.8/index.html'>1.6.8</a><br/>
-  <a href='/files/downloads/1.7.0.RC1/index.html'>1.7.0.RC1</a><br/>
-  <a href='/files/downloads/1.7.0.RC2/index.html'>1.7.0.RC2</a><br/>
-  <a href='/files/downloads/1.7.0.preview1/index.html'>1.7.0.preview1</a><br/>
-  <a href='/files/downloads/1.7.0.preview2/index.html'>1.7.0.preview2</a><br/>
-  <a href='/files/downloads/1.7.0/index.html'>1.7.0</a><br/>
-  <a href='/files/downloads/1.7.1/index.html'>1.7.1</a><br/>
-  <a href='/files/downloads/1.7.10/index.html'>1.7.10</a><br/>
-  <a href='/files/downloads/1.7.11/index.html'>1.7.11</a><br/>
-  <a href='/files/downloads/1.7.12/index.html'>1.7.12</a><br/>
-  <a href='/files/downloads/1.7.13/index.html'>1.7.13</a><br/>
-  <a href='/files/downloads/1.7.14/index.html'>1.7.14</a><br/>
-  <a href='/files/downloads/1.7.15/index.html'>1.7.15</a><br/>
-  <a href='/files/downloads/1.7.16.1/index.html'>1.7.16.1</a><br/>
-  <a href='/files/downloads/1.7.16.2/index.html'>1.7.16.2</a><br/>
-  <a href='/files/downloads/1.7.16/index.html'>1.7.16</a><br/>
-  <a href='/files/downloads/1.7.17/index.html'>1.7.17</a><br/>
-  <a href='/files/downloads/1.7.18/index.html'>1.7.18</a><br/>
-  <a href='/files/downloads/1.7.19/index.html'>1.7.19</a><br/>
-  <a href='/files/downloads/1.7.20/index.html'>1.7.20</a><br/>
-  <a href='/files/downloads/1.7.20.1/index.html'>1.7.20.1</a><br/>
-  <a href='/files/downloads/1.7.21/index.html'>1.7.21</a><br/>
-  <a href='/files/downloads/1.7.22/index.html'>1.7.22</a><br/>
-  <a href='/files/downloads/1.7.23/index.html'>1.7.23</a><br/>
-  <a href='/files/downloads/1.7.24/index.html'>1.7.24</a><br/>
-  <a href='/files/downloads/1.7.25/index.html'>1.7.25</a><br/>
-  <a href='/files/downloads/1.7.26/index.html'>1.7.26</a><br/>
-  <a href='/files/downloads/1.7.27/index.html'>1.7.27</a><br/>
-  <a href='/files/downloads/1.7.2/index.html'>1.7.2</a><br/>
-  <a href='/files/downloads/1.7.3/index.html'>1.7.3</a><br/>
-  <a href='/files/downloads/1.7.4/index.html'>1.7.4</a><br/>
-  <a href='/files/downloads/1.7.5/index.html'>1.7.5</a><br/>
-  <a href='/files/downloads/1.7.6/index.html'>1.7.6</a><br/>
-  <a href='/files/downloads/1.7.7/index.html'>1.7.7</a><br/>
-  <a href='/files/downloads/1.7.8/index.html'>1.7.8</a><br/>
-  <a href='/files/downloads/1.7.9/index.html'>1.7.9</a><br/>
-  <a href='/files/downloads/9.0.0.0.pre1/index.html'>9.0.0.0.pre1</a><br/>
-  <a href='/files/downloads/9.0.0.0.pre2/index.html'>9.0.0.0.pre2</a><br/>
-  <a href='/files/downloads/9.0.0.0.rc1/index.html'>9.0.0.0.rc1</a><br/>
-  <a href='/files/downloads/9.0.0.0.rc2/index.html'>9.0.0.0.rc2</a><br/>
-  <a href='/files/downloads/9.0.0.0/index.html'>9.0.0.0</a><br/>
-  <a href='/files/downloads/9.0.1.0/index.html'>9.0.1.0</a><br/>
-  <a href='/files/downloads/9.0.2.0/index.html'>9.0.2.0</a><br/>
-  <a href='/files/downloads/9.0.3.0/index.html'>9.0.3.0</a><br/>
-  <a href='/files/downloads/9.0.4.0/index.html'>9.0.4.0</a><br/>
-  <a href='/files/downloads/9.0.5.0/index.html'>9.0.5.0</a><br/>
-  <a href='/files/downloads/9.1.0.0/index.html'>9.1.0.0</a><br/>
-  <a href='/files/downloads/9.1.1.0/index.html'>9.1.1.0</a><br/>
-  <a href='/files/downloads/9.1.2.0/index.html'>9.1.2.0</a><br/>
-  <a href='/files/downloads/9.1.3.0/index.html'>9.1.3.0</a><br/>
-  <a href='/files/downloads/9.1.4.0/index.html'>9.1.4.0</a><br/>
-  <a href='/files/downloads/9.1.5.0/index.html'>9.1.5.0</a><br/>
-  <a href='/files/downloads/9.1.6.0/index.html'>9.1.6.0</a><br/>
-  <a href='/files/downloads/9.1.7.0/index.html'>9.1.7.0</a><br/>
-  <a href='/files/downloads/9.1.8.0/index.html'>9.1.8.0</a><br/>
-  <a href='/files/downloads/9.1.9.0/index.html'>9.1.9.0</a><br/>
-  <a href='/files/downloads/9.1.10.0/index.html'>9.1.10.0</a><br/>
-  <a href='/files/downloads/9.1.11.0/index.html'>9.1.11.0</a><br/>
-  <a href='/files/downloads/9.1.12.0/index.html'>9.1.12.0</a><br/>
-  <a href='/files/downloads/9.1.13.0/index.html'>9.1.13.0</a><br/>
-  <a href='/files/downloads/9.1.14.0/index.html'>9.1.14.0</a><br/>
-  <a href='/files/downloads/9.1.15.0/index.html'>9.1.15.0</a><br/>
+
+  <table>
+    <thead>
+      <tr>
+        <th>JRuby version</th>
+        <th>Ruby version</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href='/files/downloads/0.9.0/index.html'>0.9.0</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/0.9.1/index.html'>0.9.1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/0.9.2/index.html'>0.9.2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/0.9.8/index.html'>0.9.8</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/0.9.9/index.html'>0.9.9</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.0.0RC1/index.html'>1.0.0RC1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.0.0RC2/index.html'>1.0.0RC2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.0.0RC3/index.html'>1.0.0RC3</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.0.1/index.html'>1.0.1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.0.2/index.html'>1.0.2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.0.3/index.html'>1.0.3</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.0/index.html'>1.0</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1.1/index.html'>1.1.1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1.2/index.html'>1.1.2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1.3/index.html'>1.1.3</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1.4/index.html'>1.1.4</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1.5/index.html'>1.1.5</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1.6/index.html'>1.1.6</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1.6RC1/index.html'>1.1.6RC1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1/index.html'>1.1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1RC1/index.html'>1.1RC1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1RC2/index.html'>1.1RC2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1RC3/index.html'>1.1RC3</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.1b1/index.html'>1.1b1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.2.0/index.html'>1.2.0</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.2.0RC1/index.html'>1.2.0RC1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.2.0RC2/index.html'>1.2.0RC2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.3.0/index.html'>1.3.0</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.3.0RC1/index.html'>1.3.0RC1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.3.0RC2/index.html'>1.3.0RC2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.3.1/index.html'>1.3.1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.4.0/index.html'>1.4.0</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.4.0RC1/index.html'>1.4.0RC1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.4.0RC2/index.html'>1.4.0RC2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.4.0RC3/index.html'>1.4.0RC3</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.4.1/index.html'>1.4.1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.5.0.RC1/index.html'>1.5.0.RC1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.5.0.RC2/index.html'>1.5.0.RC2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.5.0.RC3/index.html'>1.5.0.RC3</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.5.0/index.html'>1.5.0</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.5.1/index.html'>1.5.1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.5.2/index.html'>1.5.2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.5.3/index.html'>1.5.3</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.5.4/index.html'>1.5.4</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.5.5/index.html'>1.5.5</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.5.6/index.html'>1.5.6</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.0.RC1/index.html'>1.6.0.RC1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.0.RC2/index.html'>1.6.0.RC2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.0.RC3/index.html'>1.6.0.RC3</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.0/index.html'>1.6.0</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.1/index.html'>1.6.1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.2/index.html'>1.6.2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.3/index.html'>1.6.3</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.4/index.html'>1.6.4</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.5.1/index.html'>1.6.5.1</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.5/index.html'>1.6.5</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.6/index.html'>1.6.6</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.7.2/index.html'>1.6.7.2</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.7/index.html'>1.6.7</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.6.8/index.html'>1.6.8</a></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.0.RC1/index.html'>1.7.0.RC1</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.0.RC2/index.html'>1.7.0.RC2</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.0.preview1/index.html'>1.7.0.preview1</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.0.preview2/index.html'>1.7.0.preview2</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.0/index.html'>1.7.0</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.1/index.html'>1.7.1</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.10/index.html'>1.7.10</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.11/index.html'>1.7.11</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.12/index.html'>1.7.12</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.13/index.html'>1.7.13</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.14/index.html'>1.7.14</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.15/index.html'>1.7.15</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.16.1/index.html'>1.7.16.1</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.16.2/index.html'>1.7.16.2</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.16/index.html'>1.7.16</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.17/index.html'>1.7.17</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.18/index.html'>1.7.18</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.19/index.html'>1.7.19</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.20/index.html'>1.7.20</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.20.1/index.html'>1.7.20.1</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.21/index.html'>1.7.21</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.22/index.html'>1.7.22</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.23/index.html'>1.7.23</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.24/index.html'>1.7.24</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.25/index.html'>1.7.25</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.26/index.html'>1.7.26</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.27/index.html'>1.7.27</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.2/index.html'>1.7.2</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.3/index.html'>1.7.3</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.4/index.html'>1.7.4</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.5/index.html'>1.7.5</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.6/index.html'>1.7.6</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.7/index.html'>1.7.7</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.8/index.html'>1.7.8</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/1.7.9/index.html'>1.7.9</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.0.0.0.pre1/index.html'>9.0.0.0.pre1</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.0.0.0.pre2/index.html'>9.0.0.0.pre2</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.0.0.0.rc1/index.html'>9.0.0.0.rc1</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.0.0.0.rc2/index.html'>9.0.0.0.rc2</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.0.0.0/index.html'>9.0.0.0</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.0.1.0/index.html'>9.0.1.0</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.0.2.0/index.html'>9.0.2.0</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.0.3.0/index.html'>9.0.3.0</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.0.4.0/index.html'>9.0.4.0</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.0.5.0/index.html'>9.0.5.0</a></td>
+        <td>1.8 or 1.9</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.0.0/index.html'>9.1.0.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.1.0/index.html'>9.1.1.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.2.0/index.html'>9.1.2.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.3.0/index.html'>9.1.3.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.4.0/index.html'>9.1.4.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.5.0/index.html'>9.1.5.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.6.0/index.html'>9.1.6.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.7.0/index.html'>9.1.7.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.8.0/index.html'>9.1.8.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.9.0/index.html'>9.1.9.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.10.0/index.html'>9.1.10.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.11.0/index.html'>9.1.11.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.12.0/index.html'>9.1.12.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.13.0/index.html'>9.1.13.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.14.0/index.html'>9.1.14.0</a></td>
+        <td>2.3</td>
+      </tr>
+      <tr>
+        <td><a href='/files/downloads/9.1.15.0/index.html'>9.1.15.0</a></td>
+        <td>2.3</td>
+      </tr>
+    </tbody>
+  </table>
   <a href='/files/downloads/community-ruby/index.html'>community-ruby</a><br/>
   <a href='https://s3.amazonaws.com/jruby.org/downloads/index.txt'>index.txt</a><br/>
 </p>


### PR DESCRIPTION
This is an addition that I would like added to the downloads page. I had a brief conversation on the IRC chat that precipitated this change. I've copied a snippet of that conversation here:

```
ebowling: there is a mapping but we do not have a table on a site (which might be a good idea) 1.7 -> (1.8 or 1.9), 9.1.x (2.3.y)
ebowling: 9.2.x will be 2.4 and 9.3 will be 2.5
```

I don't have any ruby lang version to add for jruby versions 0.9 - 1.6. Since they're older versions maybe that's ok.