### PR TITLE
Mention Ruby 2.6 compatibility on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ title: Home
           <div class="feature ruby" id="feature_2">
             <h3>It's Just Ruby</h3>
             
-              Ruby 2.5 compatible
+              Ruby 2.6 compatible
             
           </div>
           <div class="feature platform" id="feature_3">


### PR DESCRIPTION
With most recent release, JRuby is now compatible with Ruby 2.6, not 2.5. This would be a nice thing to reflect on the homepage too.