### PR TITLE
Fix broken Engine Yard logo on home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -49,7 +49,7 @@
       </div>
     </div>
 <div style="padding: 2em">
-  <p text-align="center">Historical releases hosted by <a href="https://www.engineyard.com/"><br/><img alt="Engine Yard" src="https://www.engineyard.com/hubfs/Engine-Yard-June-2017-theme/Images/footer-logo.svg?t=1529592952452"></a>
+  <p text-align="center">Historical releases hosted by <a href="https://www.engineyard.com/"><br/><img alt="Engine Yard" src="https://www.engineyard.com/wp-content/uploads/2021/10/Engine-Yard-Logo-4.svg" style="width: 179.06px; height: 28.08px;"></a>
   </p>
 </div>
     <div id="footer">


### PR DESCRIPTION
The Engine Yard logo on the home page is broken (HTTP 404):
<img width="197" alt="jruby-website-broken-engine-yard-logo" src="https://github.com/jruby/jruby.github.io/assets/959381/228e41a7-8b7e-48f9-95e6-89dfe3912039">
Replace it with an updated logo.