### PR TITLE
Remove outdated links from documentation.markdown

### DIFF
--- a/documentation.markdown
+++ b/documentation.markdown
@@ -13,20 +13,12 @@ We greatly appreciate patches and pull requests for documentation
 updates. Please visit the [**Contribute**](/contribute) page for more
 information on sending JRuby source patches.
 
-### Recent Articles
+### Articles
 
-* [My experience architecting a software development stack with JRuby, OpenJDK, and Roda (2019-07-10)](https://www.retroaxis.info/2019/07/10/my-experience-architecting-a-software-development-stack-with-jruby-openjdk-and-roda/)
-* [The Pleasures of JRuby: Leap Motion Hacking and JRuby](http://www.leaphacking.com/posts/the-pleasures-of-jruby.html)
-* [Deploying with JRuby in the Cloud](http://pragprog.com/magazines/2013-02/deploying-with-jruby-in-the-cloud)
 * [Riding JRuby on Rails on SAP NetWeaver Cloud: the cloud case](https://blogs.sap.com/2013/02/04/riding-jruby-on-rails-on-sap-netweaver-cloud-the-cloud-case/)
 * [RailsCasts #376: JRuby Basics](http://railscasts.com/episodes/376-jruby-basics?view=asciicast)
 * [Zero-Downtime Deploys with JRuby](https://deployingjruby.blogspot.com/2012/05/zero-downtime-deploys-with-jruby.html)
 * [JRuby Rake Vs Ant](https://watchitlater.com/blog/2011/03/jruby-rake-vs-ant/)
-
-### Recent Videos
-
-* [Why JRuby Works](https://confreaks.tv/videos/rubyconf2012-why-jruby-works)
-* [Deploy, Scale and Sleep at Night with JRuby](https://confreaks.tv/videos/gogaruco2012-deploy-scale-and-sleep-at-night-with-jruby)
 
 ### Wiki
 


### PR DESCRIPTION
This (minimally) fixes https://github.com/jruby/jruby/issues/8065